### PR TITLE
Added ability to override static error pages

### DIFF
--- a/packages/server/error/index.js
+++ b/packages/server/error/index.js
@@ -7,9 +7,24 @@ let templates = {
   '404': template(fs.readFileSync(path.join(__dirname, 'views/404.html'))),
   '500': template(fs.readFileSync(path.join(__dirname, 'views/500.html')))
 }
-let style = fs.readFileSync(path.join(__dirname, 'styles/index.css'))
+
+// Override/extend default error pages
+// each template should be named in that way: <error_code>.html
+const readFilesFromDir = dirPath => {
+  fs.readdirSync(dirPath).forEach(file => {
+    const fileName = file.split('.').shift()
+    // Check that file name starts with error_code
+    if (Number.isNaN(fileName)) return null
+    const fileContent = template(fs.readFileSync(path.join(dirPath, file)))
+    templates[fileName] = fileContent
+  })
+}
 
 module.exports = (options = {}) => {
+  if (options.errorPagesPath) {
+    readFilesFromDir(path.join(options.dirname, options.errorPagesPath))
+  }
+
   return (err, req, res, next) => {
     console.log(err.stack ? err.stack : err)
 
@@ -32,8 +47,7 @@ module.exports = (options = {}) => {
         res.redirect(options.loginUrl || '/')
       } else {
         res.status(status).send(templates[status]({
-          url: req.url,
-          style: style
+          url: req.url
         }))
       }
     } else {

--- a/packages/server/error/styles/index.css
+++ b/packages/server/error/styles/index.css
@@ -1,4 +1,0 @@
-body {
-  padding-top: 60px;
-  padding-left: 40px;
-}

--- a/packages/server/error/views/403.html
+++ b/packages/server/error/views/403.html
@@ -1,6 +1,11 @@
 <head>
   <title>Forbidden</title>
-  <style><%= style %></style>
+  <style>
+    body {
+      padding-top: 60px;
+      padding-left: 40px;
+    }
+  </style>
 </head>
 
 <body>

--- a/packages/server/error/views/404.html
+++ b/packages/server/error/views/404.html
@@ -1,6 +1,11 @@
 <head>
   <title>Not found</title>
-  <style><%= style %></style>
+  <style>
+    body {
+      padding-top: 60px;
+      padding-left: 40px;
+    }
+  </style>
 </head>
 
 <body>

--- a/packages/server/error/views/500.html
+++ b/packages/server/error/views/500.html
@@ -1,6 +1,11 @@
 <head>
   <title>Internal server error</title>
-  <style><%= style %></style>
+  <style>
+    body {
+      padding-top: 60px;
+      padding-left: 40px;
+    }
+  </style>
 </head>
 
 <body>


### PR DESCRIPTION
Now If you want to override default error pages (like 404, 500 etc.) you can create the directory ./templates in root folder 